### PR TITLE
Errata corrige 1.0.0 - Fixing typos and more (up to chapter 7 "Esercizi su first/follow")

### DIFF
--- a/src/chapters/03/chapter03.tex
+++ b/src/chapters/03/chapter03.tex
@@ -314,7 +314,7 @@ Si segua lentamente formulazione e dimostrazione per questo tanto articolato qua
 
 \subsection{Applicazioni}
   \paragraph{Scopo del pumping lemma}
-  Tutto (quasi) bello, ma a cosa serve questo pumping lemma? È presto detto: il pumping lemma di permette di determinare con certezza se un certo linguaggio \(\L\) \emph{non} è libero. Perché mai dovremmo volere questa informazione? Perché gli algoritmi di parsing\footnote{Il processo inverso della derivazione; non abbiate fretta, che fra poco arrivano un centinaio di pagine solo su quello.} che abbiamo a disposizione per verificare se una parola appartiente a un linguaggio generato da una grammatica libera sono esageratamente più efficienti di quelli che abbiamo per per i linguaggi generati da grammatiche dipendenti da contesto\footnote{Tutti questi algoritmi sono al più \(\mathcal{O}(n^3)\), ma per i linguaggi generati da alcune sottoclassi di grammatiche libere abbiamo a disposizione algoritmi lineari.}.
+  Tutto (quasi) bello, ma a cosa serve questo pumping lemma? È presto detto: il pumping lemma ci permette di determinare con certezza se un certo linguaggio \(\L\) \emph{non} è libero. Perché mai dovremmo volere questa informazione? Perché gli algoritmi di parsing\footnote{Il processo inverso della derivazione; non abbiate fretta, che fra poco arrivano un centinaio di pagine solo su quello.} che abbiamo a disposizione per verificare se una parola appartiente a un linguaggio generato da una grammatica libera sono esageratamente più efficienti di quelli che abbiamo per per i linguaggi generati da grammatiche dipendenti da contesto\footnote{Tutti questi algoritmi sono al più \(\mathcal{O}(n^3)\), ma per i linguaggi generati da alcune sottoclassi di grammatiche libere abbiamo a disposizione algoritmi lineari.}.
 
   \paragraph{Il negato del pumping lemma}
   Di preciso, come possiamo usare il pumping lemma per ottenere quest'informazione? Pensiamo al fatto che questo lemma è, formalmente, una semplice implicazione logica \(A \implies B\), dove l' ipotesi \(A\) è che un certo linguaggio \(\L\) sia libero e \(B\) è invece la tesi stessa del pumping lemma, la quale afferma che \(\L\) avrà una certa forma. Questo vuol dire che, usando il suo negato \(\neg (A \implies B) \equiv \neg B \implies \neg A\), possiamo vedere come verificare il negato della tesi del pumping lemma per un linguaggio \(\L\) implichi necessariamente che \(\L\) non è libero:
@@ -565,7 +565,7 @@ Intuitivamente, è facile convincersene: supponiamo infatti di produrre, a parti
 
 \begin{itemize}
   \item se applichiamo \(B\; \to\; 1\) andiamo a chiudere la derivazione con una stringa "bilanciata" (si passi sopra all'abuso di terminologia);
-  \item se invece abblichiamo la seconda produzione possibile (\(B\; \to\; 1S\)) non stiamo facendo altro che tornare al caso base del ragionamento, mantenendo comunque una stringa bilanciata;
+  \item se invece applichiamo la seconda produzione possibile (\(B\; \to\; 1S\)) non stiamo facendo altro che tornare al caso base del ragionamento, mantenendo comunque una stringa bilanciata;
   \item l'unico modo che abbiamo per introdurre un altro \(0\) è applicare la terza produzione \(S\; \to\; 0BB\), ma quei due \(B\), a questo punto, non hanno altro modo di terminare se non diventando degli \(1\).
 \end{itemize}
 

--- a/src/chapters/03/chapter03.tex
+++ b/src/chapters/03/chapter03.tex
@@ -266,7 +266,7 @@ Si segua lentamente formulazione e dimostrazione per questo tanto articolato qua
     \centering
     \includegraphics[width=.25\textwidth,keepaspectratio]{pl-proof_1}
   \end{figure}
-  Possiamo dire, nelle due occorrenze di \(A\), sono radicati due sottoalberi distinti, che noi qui rappresenteremo colorati di verde e porpora. La parola \(z\) può quindi essere "spacchettata" in cinque sottoparole, come illustrato di seguito.
+  Possiamo dire che, nelle due occorrenze di \(A\), sono radicati due sottoalberi distinti, che noi qui rappresenteremo colorati di verde e porpora. La parola \(z\) può quindi essere "spacchettata" in cinque sottoparole, come illustrato di seguito.
   \begin{figure}
     \centering
     \includegraphics[width=.8\textwidth,keepaspectratio]{pl-proof_2}

--- a/src/chapters/04/chapter04.tex
+++ b/src/chapters/04/chapter04.tex
@@ -240,7 +240,7 @@ La costruzione di Thompson è una procedura algoritmica che permette di costruir
 \subsection{Definizione}
 Anche questa costruzione è espressa in modo induttivo.
 \begin{labeling}{Step}
-    \item[Base] Ogni simbolo di un qualche alfabeto alfabeto \(a \in \mathcal{A}\), così come anche la parola vuota \(\varepsilon\), sono un'espressione regolare\(r\); assumiamo di avere sempre un NFA che riconosce \(\mathcal{L}(\varepsilon)\) e uno che riconosce \(\mathcal{L}(a) \; \forall a \in \mathcal{A}\).
+    \item[Base] Ogni simbolo di un qualche alfabeto alfabeto \(a \in \mathcal{A}\), così come anche la parola vuota \(\varepsilon\), sono un'espressione regolare \(r\); assumiamo di avere sempre un NFA che riconosce \(\mathcal{L}(\varepsilon)\) e uno che riconosce \(\mathcal{L}(a) \; \forall a \in \mathcal{A}\).
     \item[Step] L'espressione regolare \(r\) è una tra le seguenti opzioni: 
     \begin{itemize}[noitemsep]
         \item \(r_1 \mid  r_2 \);

--- a/src/chapters/06/chapter06.tex
+++ b/src/chapters/06/chapter06.tex
@@ -152,7 +152,7 @@ Adesso dobbiamo pensare come ottimizzare l'uso di una struttura simile per l'ana
 Il procedimento che seguiamo è il seguente:
 \begin{enumerate}
     \item innanzitutto simuliamo l'NFA creato come sopra descritto;
-    \item nel caso di ambiguità, ossia di situazioni come quella descritta sopra tra \mintinline{c}{if} e \mintinline{c}{iffoff}, la convenzione è di preoseguire la simulazione finché nessun’altra transizione è possibile, solitamente quando incontriamo uno spazio o un \texttt{\(\backslash\)n}, privilegiando quindi il match più lungo (si parla di cercare il \emph{longest match});
+    \item nel caso di ambiguità, ossia di situazioni come quella descritta sopra tra \mintinline{c}{if} e \mintinline{c}{iffoff}, la convenzione è di proseguire la simulazione finché nessun’altra transizione è possibile, solitamente quando incontriamo uno spazio o un \texttt{\(\backslash\)n}, privilegiando quindi il match più lungo (si parla di cercare il \emph{longest match});
     \item se nell'insieme di stati che abbiamo raggiunto ci sono delle azioni disponibili, allora andremo ad eseguire quella appartenente al longest match, in caso di pareggio ciascuna azione avrà una priorità, e noi eseguiremo quella con più alta priorità;
     \item se nessun'azione è disponibile, dobbiamo invece tornare indietro nella sequenza di stati percorsi, fermarci nel primo insieme di stati che presenta almeno uno stato finale e delle azioni associate e cercare di nuovo quella prioritaria; per ognuno di questi passi all'indietro, dobbiamo ricordarci di aggiornare il puntatore all'input buffer.
 \end{enumerate}

--- a/src/chapters/07/assets/pseudocode/follow.tex
+++ b/src/chapters/07/assets/pseudocode/follow.tex
@@ -26,7 +26,7 @@
         \Repeat{saturation} {
             \ForEach{\(B \to \alpha A \beta\)} {
                 \If{\(\beta \ne \varepsilon\)} {
-                    \Follow{\(A\)}.\Add{\First{\beta} \(\setminus \{\varepsilon\}\)}\;
+                    \Follow{\(A\)}.\Add{\First{\(\beta\)} \(\setminus \{\varepsilon\}\)}\;
                 }
                 \If{\(\beta\) = \(\varepsilon \lor \varepsilon \in\) \First{\(\beta\)}} {
                     \Follow{\(A\)}.\Add{\Follow{\(B\)}}\;

--- a/src/chapters/07/chapter07.tex
+++ b/src/chapters/07/chapter07.tex
@@ -766,7 +766,7 @@ Ma, allo stesso identico modo, potremmo completare lo stesso albero parziale e o
 Anche qui, non possiamo fare altro che concludere che applicare la procedura di eliminazione della ricorsione sinistra su una grammatica ambigua \emph{non} ne elimina l'ambiguità.
 
 \section{Fattorizzabilità Sinistra}
-Consideriamo ora la grammatica \(\G: S \rightarrow aSb \mid ab\), che ormai ben conosciamo: questa grammatica ci permette di denotare, ad esempio, un linguaggio composto da parentesi annidate. Quello che non sapevamo è che non è una grammatica \(LL(1)\): ce ne possiamo accorgere calcolandone i \(first(S)\). Dal momento che l'unico elemento appartenente a questo insieme, nel caso delle due produzioni, risulta infatti essere il non-terminale \(a\), questo vuol dire che, applicando l'algoritmo per la generazione della tabella di parsing predittivo, ci troveremo con due produzioni nella posizione \(M[S, a]\).
+Consideriamo ora la grammatica \(\G: S \rightarrow aSb \mid ab\), che ormai ben conosciamo: questa grammatica ci permette di denotare, ad esempio, un linguaggio composto da parentesi annidate. Quello che non sapevamo è che non è una grammatica \(LL(1)\): ce ne possiamo accorgere calcolandone i \(first(S)\). Dal momento che l'unico elemento appartenente a questo insieme, nel caso delle due produzioni, risulta infatti essere il terminale \(a\), questo vuol dire che, applicando l'algoritmo per la generazione della tabella di parsing predittivo, ci troveremo con due produzioni nella posizione \(M[S, a]\).
 
 Il punto è che \(\G\) può essere \textbf{fattorizzata a sinistra}; in generale, una grammatica è fattorizzabile a sinistra quando:
 \begin{itemize}

--- a/src/chapters/07/chapter07.tex
+++ b/src/chapters/07/chapter07.tex
@@ -318,7 +318,7 @@ Utilizziamo sempre la grammatica dell'esempio precedente, che qui riportiamo per
 
 Un caso che potrebbe risultare interessante riguarda la produzione \(F \rightarrow (E)\). Poniamo come fatto precedentemente \(A = E\): essendo che \(\beta = \textrm{ } ) \neq \varepsilon\), è necessario aggiungere \(first(\beta) \setminus \{\varepsilon\} = \{)\}\) a \(follow(E)\); visto che la seconda condizione non è vera, possiamo fermarci ed affermare che \(follow(E) = \{\$, )\}\).
 
-Inoltre, nei punti in cui si deovno aggiungere ai follow di un non-terminale i follow di un altro si lasciano delle annotazioni che si andranno a risolvere una volta terminata l'analisi di tutte le produzioni. Il risultato finale verrà rappresentato come segue:
+Inoltre, nei punti in cui si devono aggiungere ai follow di un non-terminale i follow di un altro si lasciano delle annotazioni che si andranno a risolvere una volta terminata l'analisi di tutte le produzioni. Il risultato finale verrà rappresentato come segue:
 \begin{table}[H]
 	\centering
 	\subimport{assets/tables/}{computing-follow.tex}

--- a/src/chapters/07/chapter07.tex
+++ b/src/chapters/07/chapter07.tex
@@ -879,7 +879,7 @@ Si può infatti notare che
 	\item nell'altro invece è possibile sostituire \({S'}_1\) con \texttt{else} \(c\) e \({S'}_2\) con \(\varepsilon\);
 \end{itemize}
 
-In entrambi i casi si arrivare di fatto alla stessa stringa da due alberi di derivazione differenti (ottenuti impiegando due derivazioni leftmost).
+In entrambi i casi si arriva di fatto alla stessa stringa da due alberi di derivazione differenti (ottenuti impiegando due derivazioni leftmost).
 
 Questo problema viene definito \emph{dangling else} e corrisponde a non sapere identificare in maniera certa a quale \texttt{then} appartenga un determinato \texttt{else}. Per poter risolvere tale problematica vi sono due differenti soluzioni:
 \begin{itemize}

--- a/src/chapters/07/chapter07.tex
+++ b/src/chapters/07/chapter07.tex
@@ -64,7 +64,7 @@ Nel caso del predictive top-down parsing non è mai necessario applicare la tecn
 \begin{itemize}
     \item guardiamo le parole da sinistra a destra;
     \item eseguiamo una produzione leftmost;
-    \item guardiamo un solo non-terminale per decidere quale produzione utilizzare .
+    \item guardiamo un solo non-terminale per decidere quale produzione utilizzare.
 \end{itemize}
 Tali grammatiche prevedono una tipologia di parsing per cui non è necessario backtrack, e per di più è \textbf{completamente deterministica}.
 
@@ -309,7 +309,7 @@ Utilizziamo sempre la grammatica dell'esempio precedente, che qui riportiamo per
 \begin{enumerate}
     \item Dall'algoritmo sappiamo di dover inizializzare \(follow(E) = \$\).
     \item Iniziamo guardando la prima produzione, cioè \(E \rightarrow TE'\): se poniamo \(A = E'\), allora \(\beta = \varepsilon\) e quindi dobbiamo aggiungere i \(follow(E)\) (quelli del driver) a \(follow(E')\) (quelli del body).
-    \item Sempre soffermandoci sulla stessa produzione poniamo \(A = T\): questo vuol dire che \(\beta = E' \neq \varepsilon\) e quindi, ricadendo nel primo caso, aggiungiamo \(first(E) \setminus \{\varepsilon\} = \{+\}\) a \(follow(T)\); tuttavia, essendo che \(\varepsilon \in first((E')\), allora ricadiamo anche nel secondo caso, per cui aggiungiamo \(follow(E)\) a \(follow(T)\).
+    \item Sempre soffermandoci sulla stessa produzione poniamo \(A = T\): questo vuol dire che \(\beta = E' \neq \varepsilon\) e quindi, ricadendo nel primo caso, aggiungiamo \(first(E') \setminus \{\varepsilon\} = \{+\}\) a \(follow(T)\); tuttavia, essendo che \(\varepsilon \in first(E')\), allora ricadiamo anche nel secondo caso, per cui aggiungiamo \(follow(E)\) a \(follow(T)\).
     \item Passiamo ora alla produzione \(E' \rightarrow +TE'\): poniamo quindi \(A = E'\) e \(\beta = \varepsilon\); ricadendo nel secondo caso dovremmo aggiungere \(follow(E')\) a \(follow(E')\) ma, dato che questo non fornisce informazioni aggiuntive, possiamo scartare questa informazione.
     \item Facendo sempre riferimento ad \(E' \rightarrow +TE'\), esaminiamo il caso per cui \(A = T\): visto che \(\beta = E'\), tale caso è identico a quello esaminato al punto 3 e porterà all'aggiunta dei medesimi terminali.
     \item L'ultimo elemento che non abbiamo preso in considerazione per la produzione corrente è terminale \(+\) ma, in quanto terminale, non possiamo calcolarne i follow.

--- a/src/chapters/08/chapter08.tex
+++ b/src/chapters/08/chapter08.tex
@@ -208,7 +208,7 @@ Questi stati però potrebbero essere già presenti! Non è questo il caso dato c
         A \to b \cdot
     \end{equation*}
     e non presenta ulteriori possibili sviluppi, quindi passiamo oltre.
-    \item Analizziamo lo stato \(\tau (3, B) = 5\). \\
+    \item Analizziamo lo stato \(\tau (3, b) = 5\). \\
     Il kernel in questo caso è:
     \begin{equation*}
         S \to aAB \cdot e


### PR DESCRIPTION
Ciao!
Ho corretto alcune typos che ho trovato qua e là.
Inoltre ho sistemato un ambiente matematico alla linea 29 del file Appunti-LFC/src/chapters/07/assets/pseudocode/follow.tex che rompeva la compilazione.