### PR TITLE
Removed multiple warnings, added instructions to compile with Latex Workshop

### DIFF
--- a/Appunti-LFC.code-workspace
+++ b/Appunti-LFC.code-workspace
@@ -5,6 +5,7 @@
 		}
 	],
 	"settings": {
+		"latex-workshop.latex.autoBuild.run": "never",
 		"latex-workshop.latex.autoClean.run": "onSucceeded",
 		"latex-workshop.latex.tools": [
 			{

--- a/Appunti-LFC.code-workspace
+++ b/Appunti-LFC.code-workspace
@@ -6,7 +6,35 @@
 	],
 	"settings": {
 		"latex-workshop.latex.autoBuild.run": "never",
-		"latex-workshop.latex.autoClean.run": "onSucceeded",
+		"latex-workshop.latex.autoClean.run": "onBuilt",
+		"latex-workshop.latex.clean.subfolder.enabled": true,
+		"latex-workshop.latex.clean.fileTypes": [
+			"*.aux",
+			"*.bbl",
+			"*.blg",
+			"*.idx",
+			"*.ind",
+			"*.lof",
+			"*.lot",
+			"*.out",
+			"*.toc",
+			"*.acn",
+			"*.acr",
+			"*.alg",
+			"*.glg",
+			"*.glo",
+			"*.gls",
+			"*.fls",
+			"*.log",
+			"*.fdb_latexmk",
+			"*.snm",
+			"*.synctex(busy)",
+			"*.synctex.gz(busy)",
+			"*.gz",
+			"*.nav",
+			"_minted*/*", //remove all minted folders content
+			"_minted*/" //remove the actual folder
+		],
 		"latex-workshop.latex.tools": [
 			{
 				"name": "pdflatex",

--- a/Appunti-LFC.code-workspace
+++ b/Appunti-LFC.code-workspace
@@ -1,0 +1,30 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"latex-workshop.latex.autoClean.run": "onSucceeded",
+		"latex-workshop.latex.tools": [
+			{
+				"name": "pdflatex",
+				"command": "pdflatex",
+				"args": [
+					"-shell-escape",
+					"-synctex=1",
+					"-interaction=nonstopmode",
+					"-file-line-error",
+					"-output-directory=%OUTDIR%",
+					"%DOC%"
+				]
+			}
+		],
+		"latex-workshop.latex.recipes": [
+			{
+				"name": "pdflatex",
+				"tools": ["pdflatex", "pdflatex", "pdflatex"]
+			}
+		]
+	}
+}

--- a/Appunti-LFC.code-workspace
+++ b/Appunti-LFC.code-workspace
@@ -25,7 +25,7 @@
 			"*.glo",
 			"*.gls",
 			"*.fls",
-			"*.log",
+			"*.log", // use log file to check errors
 			"*.fdb_latexmk",
 			"*.snm",
 			"*.synctex(busy)",

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # Appunti di Linguaggi Formali e Compilatori
+
 ![logo](src/chapters/titlepage/images/logo-unitn.png)
 
 ## Indice
+
+- [Appunti di Linguaggi Formali e Compilatori](#appunti-di-linguaggi-formali-e-compilatori)
+  - [Indice](#indice)
   - [Il progetto](#il-progetto)
   - [Segnalazione errori](#segnalazione-errori)
   - [How to build](#how-to-build)
     - [Standard build chain](#standard-build-chain)
     - [How to build with Docker](#how-to-build-with-docker)
+    - [How to build with LateX Workshop (VS Code)](#how-to-build-with-latex-workshop-vs-code)
   - [Principali pacchetti impiegati](#principali-pacchetti-impiegati)
   - [La squadra](#la-squadra)
 
 ## Il progetto
+
 Questo testo è una dispensa di appunti scritta da studenti; lo scopo è quello di raccogliere i contenuti del corso di Linugaggi Formali e Compilatori e organizzarli secondo un'esposizione quanto più completa, efficace ed intuitiva possibile, tanto per lo studente desideroso di ottenere un'ottima padronanza degli argomenti, quanto anche per lo studente pigro in cerca di risorse per "portare a casa" l'esame.
 
 Gli appunti sono stati presi durante il corso di Linguaggi Formali e Compilatori tenuto dalla professoressa Paola Quaglia per il Corso di Laurea in Informatica, DISI, Università degli studi di Trento, anno accademico 2020-2021. I contenuti provengono quindi primariamente dalle lezioni della professoressa, mentre invece ordine ed esposizione sono in gran parte originali. Allo stesso modo, la maggior parte degli assets (figure, grafi, tabelle, pseudocodici) sono contenutisticamente tratti dal materiale della professoressa, ma ricreati e molto spesso manipolati dagli autori; inoltre, per ottenere il risultato appena citato, è stato molto spesso necessario abbandonare quasi del tutto l'esposizione della professoressa e usarla, appunto, come canovaccio per svilupparne una originale.
@@ -18,42 +24,47 @@ Gli appunti sono stati presi durante il corso di Linguaggi Formali e Compilatori
 Maggiori informazioni sul progetto e e sugli autori possono essere trovate nella prefazione dell'elaborato.
 
 ## Segnalazione errori
-Se durante la lettura doveste incorrere in errori di qualsiasi tipo, tra gli altri errori di battitura, errori concettuali o di impaginazione, vi chiediamo di fare una segnalazione; ve ne saremo riconoscenti e provvederemo a correggere quanto prima. Se siete arrivati a questo punto assumiamo una buona familiarità con Github, per cui come canali per segnalare errori:
-- aprire una Github issue, se possibile referenziando all'interno del corpo anche la porzione di codice in cui è presente l'errore
-- se volete direttamente proporre un vostro fix, potete clonare la repo (istruzioni per la build [qui](#how-to-build)) e aprire una pull request con i commit che risolvono l'errore, vi daremo un riscontro quanto prima
 
-Se preferite non segnalare l'errore tramite Github potete comunque contattarci personalmente tramite gli indirizzi email che trovate [sui nostri profili Github](#la-squadra), oppure con la mail istituzionale `nome.cognome@studenti.unitn.it`, o naturalmente con mezzi più informali. 
+Se durante la lettura doveste incorrere in errori di qualsiasi tipo, tra gli altri errori di battitura, errori concettuali o di impaginazione, vi chiediamo di fare una segnalazione; ve ne saremo riconoscenti e provvederemo a correggere quanto prima. Se siete arrivati a questo punto assumiamo una buona familiarità con Github, per cui come canali per segnalare errori:
+
+-   aprire una Github issue, se possibile referenziando all'interno del corpo anche la porzione di codice in cui è presente l'errore
+-   se volete direttamente proporre un vostro fix, potete clonare la repo (istruzioni per la build [qui](#how-to-build)) e aprire una pull request con i commit che risolvono l'errore, vi daremo un riscontro quanto prima
+
+Se preferite non segnalare l'errore tramite Github potete comunque contattarci personalmente tramite gli indirizzi email che trovate [sui nostri profili Github](#la-squadra), oppure con la mail istituzionale `nome.cognome@studenti.unitn.it`, o naturalmente con mezzi più informali.
 
 ## How to build
+
 ### Standard build chain
+
 Prerequisiti:
 
-- una distribuzione TeX, ad esempio [MiKTeX](https://miktex.org/) o [TeXLive](http://tug.org/texlive/)
-- `pip`, per cui assicuratevi di aver installato [Python](https://www.python.org/)
-- se volete compilare utilizzando il tool [Arara](https://gitlab.com/islandoftex/arara/), allora dovrete avere una [JVM](https://www.java.com/) installata
+-   una distribuzione TeX, ad esempio [MiKTeX](https://miktex.org/) o [TeXLive](http://tug.org/texlive/)
+-   `pip`, per cui assicuratevi di aver installato [Python](https://www.python.org/)
+-   se volete compilare utilizzando il tool [Arara](https://gitlab.com/islandoftex/arara/), allora dovrete avere una [JVM](https://www.java.com/) installata
 
 A questo punto:
 
 1. clonate la repository con `git clone https://github.com/filippodaniotti/Appunti-LFC`
 2. installate il pacchetto Pygments con `pip install Pygments`
 3. compilate, ad esempio:
-   - lanciando tre volte `pdflatex -shell-escape main.tex`
-   - lanciando `latexmk -pdf -shell-escape main.tex`
-   - per una compilazione rapida, potete utilizzare Arara con `arara main.tex` (dovete necessariamente trovarvi nella directory `~/src/`), sarà equivalente a lanciare una sola passata di `pdflatex`
+    - lanciando tre volte `pdflatex -shell-escape main.tex`
+    - lanciando `latexmk -pdf -shell-escape main.tex`
+    - per una compilazione rapida, potete utilizzare Arara con `arara main.tex` (dovete necessariamente trovarvi nella directory `~/src/`), sarà equivalente a lanciare una sola passata di `pdflatex`
 
 È possibile compilare singolarmente ogni capitolo e ogni asset, è sufficiente lanciare la compilazione sul singolo `.tex` desiderato.
 
 Se lavorate con degli IDE o con degli editor in coppia con dei tool per la scrittura LaTeX (e.g. [VS Code](https://code.visualstudio.com) + [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) o [Atom](https://atom.io) + [latex](https://atom.io/packages/latex)), assicuratevi di attivare il flag `-shell-escape` dalle impostazioni di compilazione del vostro tool.
 
 ### How to build with Docker
+
 Se non disponete dei prerequisiti per la build indicati sopra (o non volete installarli system-wide), potete
 buildare con docker.  
 Se poi avete sia [VS Code](https://code.visualstudio.com) che [Docker](https://www.docker.com/), potete riferirvi a questo [gist](https://gist.github.com/civts/234f4e7be7d13df676937996f4d4f45c) per una configurazione già pronta.
 
 Prerequisiti:
 
-- [Docker](https://www.docker.com/)
-- almeno 5/6 GB liberi su disco
+-   [Docker](https://www.docker.com/)
+-   almeno 5/6 GB liberi su disco
 
 Procedimento:
 
@@ -61,28 +72,47 @@ Procedimento:
 2. se non siete su linux, buildate l'immagine docker contenuta nel Dockerfile con `docker build -t dispensa_lfc .`  
    Nel caso siate su linux, usate questo comando per buildare `docker build -t dispensa_lfc --build-arg UID=$(id -u) --build-arg GID=$(id -g) .` (si assicura che il vostro userId e groupId corrispondano a quelli che il container userà)
 3. avviate un container, ricordandovi di montare la cartella della dispensa/
-Esempio: `docker run -ti --rm -v $(pwd):/dispensa --name dispensa_lfc dispensa_lfc`
+   Esempio: `docker run -ti --rm -v $(pwd):/dispensa --name dispensa_lfc dispensa_lfc`
 4. ora avete accesso ad un ambiente con tutte le dipendenze installate e potete buildare usando i comandi della sezione [how to build](#How-to-build) (ad eccezione di Arara, perché il container non ha una JVM installata)
 
+### How to build with LateX Workshop (VS Code)
+
+Prerequisiti:
+
+-   [VS Code](https://code.visualstudio.com)
+-   [Latex Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) (estensione di VS Code)
+-   [TeXLive](http://tug.org/texlive/) distribuzione TeX, raccomandata dagli sviluppatori di Latex Workshop (vedi [qui](https://github.com/James-Yu/LaTeX-Workshop/wiki/Install#requirements))
+
+Procedimento:
+
+1. All'interno della repo troverete il file `Appunti-LFC.code-workspace`; in questo file di configurazione sono presenti tutte le impostazioni per compilare con successo il progetto.
+
+2. Per compilare, è sufficiente aprire il workspace con VS Code e premere `Ctrl+Alt+B` (o `Cmd+Alt+B` su Mac) se questa è la vostra shortcut, altrimenti premere il pulsante verde play (<span style="color:green;font-weight:700;font-size:20px">⊳</span>).
+
+Nota: all'interno del di `Appunti-LFC.code-workspace` oltre lo stretto necessario sono presenti diverse opzioni. Per disattivarle è sufficiente commentare o cancellare la riga corrispondente. Per maggiori informazioni consultare la documentazione sui [workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) e per le diverse opzioni di compiling quella di [Latex Workshop](https://github.com/James-Yu/LaTeX-Workshop/wiki/Compile).
+
 ## Principali pacchetti impiegati
-- `standalone` per gestire la compilazione autonoma di capitoli e assets
-- `tabularx` per la gestione delle tabelle
-- `forest` per la generazione degli alberi
-- `tikz` con librerie `automata` per la generazione dei grafi
-- `algorithm2e` per la scrittura degli pseudocodici
-- `minted` per la scrittura di codice
+
+-   `standalone` per gestire la compilazione autonoma di capitoli e assets
+-   `tabularx` per la gestione delle tabelle
+-   `forest` per la generazione degli alberi
+-   `tikz` con librerie `automata` per la generazione dei grafi
+-   `algorithm2e` per la scrittura degli pseudocodici
+-   `minted` per la scrittura di codice
 
 ## La squadra
-- Curatori
-  - [Filippo Daniotti](https://github.com/filippodaniotti)
-  - [Samuele Conti](https://github.com/samaretas)
-- Scrittori
-  - [Simone Alghisi](https://github.com/Simone-Alghisi)
-  - [Emanuele Beozzo](https://github.com/emanuelebeozzo)
-  - [Samuele Bortolotti](https://github.com/samuelebortolotti)
-- Tecnici
-  - [Francesco Bozzo](https://github.com/FrancescoBozzo)
-  - [Federico Izzo](https://github.com/fedeizzo)
-- Revisori
-  - [Michele Yin](https://github.com/BigEmperor26)
-  - [Giacomo Zanolli](https://github.com/civts)
+
+-   Curatori
+    -   [Filippo Daniotti](https://github.com/filippodaniotti)
+    -   [Samuele Conti](https://github.com/samaretas)
+-   Scrittori
+    -   [Simone Alghisi](https://github.com/Simone-Alghisi)
+    -   [Emanuele Beozzo](https://github.com/emanuelebeozzo)
+    -   [Samuele Bortolotti](https://github.com/samuelebortolotti)
+-   Tecnici
+    -   [Francesco Bozzo](https://github.com/FrancescoBozzo)
+    -   [Federico Izzo](https://github.com/fedeizzo)
+-   Revisori
+    -   [Michele Yin](https://github.com/BigEmperor26)
+    -   [Giacomo Zanolli](https://github.com/civts)
+    -   [Marco Toniolo](https://github.com/Toniolo-Marco)

--- a/src/chapters/04/assets/pseudocode/nfa-simulation.tex
+++ b/src/chapters/04/assets/pseudocode/nfa-simulation.tex
@@ -6,7 +6,6 @@
 % arara: latexmk: { clean: partial }
 \begin{document}
     \begin{algorithm}[H]
-        \label{alg:nfa-simulation}
         \DontPrintSemicolon
 
         \SetKwData{t}{\textbf{true}}

--- a/src/chapters/04/chapter04.tex
+++ b/src/chapters/04/chapter04.tex
@@ -480,7 +480,7 @@ Continuo così finché non finisco i simboli; a quel punto devo verificare se es
     
     Allora la \(\varepsilon\)-chiusura\((M)\) è il più piccolo insieme \(X \subseteq S\) tale che \(X\) è una soluzione alla seguente equazione:
     \begin{equation}
-        X = M \cup \{ N’ \mid N \in X \cap N’ \in \textrm{move}_n (N,\varepsilon)\}
+        X = M \cup \{ N^\prime \mid N \in X \cap N^\prime \in \textrm{move}_n (N,\varepsilon)\}
         \label{eps-closure-set-eq}
     \end{equation}
 \end{theorem}
@@ -494,7 +494,7 @@ Continuo così finché non finisco i simboli; a quel punto devo verificare se es
     \label{nfa_ciclico}
 \end{figure}
 
-Osserviamo con attenzione la formula appena descritta: \(X\) è \(M\) stesso, unito anche a tutti gli stati \(N’\) raggiungibili da \(N\) tramite una \(\varepsilon\)-transizione, dove \(N\) è uno stato qualsiasi in \(M\).
+Osserviamo con attenzione la formula appena descritta: \(X\) è \(M\) stesso, unito anche a tutti gli stati \(N^\prime \) raggiungibili da \(N\) tramite una \(\varepsilon\)-transizione, dove \(N\) è uno stato qualsiasi in \(M\).
 
 Balza subito all'occhio come la formula per definire \(X\) dipenda da \(X\) stessa; per questo motivo non dovremmo poterla calcolare, giusto? 
 Sbagliato! In informatica possiamo risolvere queste equazioni date certe caratteristiche, ed è qui che giunge in nostro aiuto il teorema del punto fisso. 
@@ -553,7 +553,7 @@ Andiamo quindi ad analizzare la complessità di queste procedure.
 \subsection{Complessità della costruzione di Thompson}
 Consideriamo la  complessità di generazione di un NFA con \(n\) nodi e \(m\) archi; conoscendo le quattro operazioni, sappiamo che, per ogni passo, aggiungeremo al massimo \(2\) nodi e \(4\) archi (dalla Kleene star, l'operazione più costosa), per cui avremo che \(n \le 2|r|\) e \(m \le 4|r|\), per cui abbiamo che la somma \(n + m\) è dell'ordine della dimensione dell'espressione regolare (\(\mathcal{O}(|r|)\)) e, poiché avremo in totale \(|r|\) passi, ciascuno dei quali eseguibile in tempo costante, possiamo felicemente concludere che \(T(\textrm{Thompson}(r)) = \mathcal{O}(|r|)\).
 
-\subsection{Complessità del calcolo della \(\varepsilon\)-chiusura}
+\subsection{Complessità del calcolo della \texorpdfstring{$\varepsilon$}{Epsilon}-chiusura}
 Prima di analizzare il costo della simulazione, dobbiamo analizzare il costo della \(\varepsilon\)-chiusura. Tenendo sempre a mente il codice (Alg.\ref{alg:ec-wrapper} e Alg.\ref{alg:ec-computation}), evidenziamo che le strutture usate sono:
 \begin{itemize}
     \item uno stack per contenere gli elementi non ancora incontrati;

--- a/src/chapters/04/chapter04.tex
+++ b/src/chapters/04/chapter04.tex
@@ -37,7 +37,7 @@ La precedente strategia sicuramente è ottima quando il linguaggio ha una forma 
 
 \begin{equation}
     \label{alfabeto}
-    S \to a \mid b \mid … \mid z \mid aS \mid bS \mid … \mid zS
+    S \to a \mid b \mid \cdots \mid z \mid aS \mid bS \mid \cdots \mid zS
 \end{equation}
 
 Per riconoscere parole generate da una tale grammatica il metodo di analisi naturale è una automa a stati finiti come quella in figura \ref{macchina_a_stati_finiti}.
@@ -401,7 +401,7 @@ Vediamo che leggere \(bbb\) da \(S_0\) è uguale a leggerlo da uno qualunque tra
 La risposta è sì, possiamo farlo! Per vedere in che modo dobbiamo prima introdurre il concetto di \(\varepsilon\)-chiusura.
 
 
-\subsection{\(\varepsilon\)-chiusura di un automa}
+\subsection{\texorpdfstring{$\varepsilon$}{Epsilon}-chiusura di un automa}
 Sia \((S, \mathcal{A}, \textrm{move}_n, S_0, F)\) un NFA, sia \(t\) uno stato in \(S\) e \(T\) un sottoinsieme di \(S\).
 
 Definiamo \(\varepsilon\)-chiusura\((\{t\})\) l’insieme di stati in \(S\) che sono raggiungibili da \(t\) tramite zero o più \(\varepsilon\)-transizioni (nota che \(t\) è sempre in questo insieme).
@@ -474,8 +474,7 @@ Nel secondo step il simbolo che devo aggiungere è la seconda lettera di \(w\), 
 
 Continuo così finché non finisco i simboli; a quel punto devo verificare se esiste nel mio insieme \(states\) uno stato finale. In questo caso è presente (\(10\)), e quindi la parola \(w\) appartiene al linguaggio riconosciuto dall’automa raffigurato.
 
-
-\subsection{Nota sulla \(\varepsilon\)-chiusura}
+\subsection{Nota sulla \texorpdfstring{$\varepsilon$}{Epsilon}-chiusura}
 \begin{theorem}
     Sia \(N = (S, \mathcal{A}, \textrm{move}_n, S_0, F)\) un NFA e sia \(M \subseteq S\).
     

--- a/src/chapters/04/chapter04.tex
+++ b/src/chapters/04/chapter04.tex
@@ -433,6 +433,7 @@ Continuiamo così finché lo stack non si svuota. L'algoritmo appena descritto s
 % \end{algorithm}
 Ora che abbiamo l'arma della \(\varepsilon\)-chiusura possiamo procedere con l'algoritmo per la verifica dell'appartenenza di una parola \(w\) al linguaggio riconosciuto da un automa, ovvero l'algoritmo di simulazione (Alg.\ref{alg:nfa-simulation}).
 
+\label{alg:nfa-simulation}
 \subimport{assets/pseudocode/}{nfa-simulation.tex}
 Dove \texttt{\$} è l’end-marker per la parola \(w\) (alcuni testi usano la “gratella” invece che \texttt{\$}).
 Il funzionamento dell'algoritmo è questo: calcoliamo la \(\varepsilon\)-chiusura di \(S_0\) e la aggiungiamo all'insieme \texttt{states}; prendiamo il primo simbolo nella parola tramite \(nextChar()\) e poi entriamo nel ciclo che compone il corpo della procedura.

--- a/src/chapters/07/chapter07.tex
+++ b/src/chapters/07/chapter07.tex
@@ -205,7 +205,7 @@ In questo esempio, invece, il linguaggio denotato dalla nostra grammatica è com
     \label{filling-parsing-table2}
 \end{table}
 
-\section{First(\(\alpha\))}
+\section{First(\texorpdfstring{$\alpha$}{Alpha})} 
 \subsection{Definizione}
 \begin{definition}
     Chiamiamo \(first(\alpha)\) quell'insieme di terminali che sono posti all'inizio delle stringhe derivate da \(\alpha\).
@@ -226,7 +226,7 @@ Il concetto di \(first\) può essere definito ricorsivamente come segue:
 
     Nell'ultimo caso, quello ricorsivo, si ha che \(first(A)\) è dato dall'unione di tutti i \(first(\alpha)\), dove \(\alpha\) è il body di tutte quelle produzioni della grammatica che hanno \(A\) come driver.
 
-\subsection{Algoritmo di calcolo di first(\(\alpha\))}
+\subsection{Algoritmo di calcolo di first(\texorpdfstring{$\alpha$}{Alpha})}
 
 Mostriamo ora un algoritmo che ci permette di calcolare \(first(Y_1 \ldots Y_n)\) (con \(Y_i \in V\)), cioè l'insieme dei first per una certa parola considerata.
 
@@ -274,9 +274,9 @@ A questo punto, il miglior modo per procedere con l'algoritmo è, in mancanza di
     \caption{Esercizio sui first}
     \label{computing-first}
 \end{table}
-Cosa succede se invece, al posto della produzione \(T \to FT'\), diventa \(T \to T’F\)? Lasciando il resto dell'esercizio invariato, proviamo a calcolare \(first(T)\). In questo caso avremmo dovuto analizzare prima i \(first(T’) = \{\varepsilon, \ast\}\) e aggiungere \(first(T’) \setminus \{\varepsilon\} = \{\ast\}\) a \(first(T)\); tuttavia, dal momento che \(\varepsilon \in first(T')\), l’algoritmo non può arrestarsi (perchè potrebbe darsi che \(T'\) sia nullo), ma è necessario considerare anche i \(first(F)\). Come svolto precedenetemente aggiungiamo \(first(F) \setminus \{\varepsilon\} = \{id, (\}\) a \(first(T)\); essendo che \(\varepsilon \notin first(T')\) posso interrompere l'algoritmo e segnare che \(first(T) = \{\ast, id, (\}\)
+Cosa succede se invece, al posto della produzione \(T \to FT^\prime \), diventa \(T \to T^\prime F\)? Lasciando il resto dell'esercizio invariato, proviamo a calcolare \(first(T)\). In questo caso avremmo dovuto analizzare prima i \(first(T ^\prime) = \{\varepsilon, \ast\}\) e aggiungere \(first(T ^\prime) \setminus \{\varepsilon\} = \{\ast\}\) a \(first(T)\); tuttavia, dal momento che \(\varepsilon \in first(T ^\prime)\), l’algoritmo non può arrestarsi (perchè potrebbe darsi che \(T ^\prime \) sia nullo), ma è necessario considerare anche i \(first(F)\). Come svolto precedenetemente aggiungiamo \(first(F) \setminus \{\varepsilon\} = \{id, (\}\) a \(first(T)\); essendo che \(\varepsilon \notin first(T ^\prime)\) posso interrompere l'algoritmo e segnare che \(first(T) = \{\ast, id, (\}\)
 
-\section{Follow(\(A\))}
+\section{Follow(\texorpdfstring{${A}$}{A})} 
 \subsection{Definizione}
 A differenza dei \emph{first}, che sono definiti per stringhe generiche di terminali e non-terminali, i \emph{follow} sono computati solamente per i non-terminali: scriveremo dunque \(follow(A)\).
 \begin{definition}
@@ -284,7 +284,7 @@ A differenza dei \emph{first}, che sono definiti per stringhe generiche di termi
 \end{definition}
 I \emph{first} evidenziano quali sono i terminali per cui iniziano le stringhe derivabili da certi elementi (stringhe o non-terminali), i \emph{follow} invece indicano quali sono i terminali che possono seguire.
 
-\subsection{Algoritmo per il calcolo dei follow(\(A\))}
+\subsection{Algoritmo per il calcolo dei follow(\texorpdfstring{${A}$}{A})}
 \subimport{assets/pseudocode/}{follow.tex}
 L'algoritmo comincia inizializzando \(follow(S) = \$\): dal momento che dallo start symbol si possono generare tutte le possibili parole appartenenti al linguaggio della grammatica, allora possiamo aspettarci di trovare il terminatore di stringa \$ dopo una qualsiasi parola. Negli altri casi, invece, \(\forall A\) tale che \(A\) è un non-terminale, inizializziamo \(follow(A) = \emptyset\).
 
@@ -648,7 +648,6 @@ Fermiamoci un attimo e facciamo il punto della situazione. Prima di questa ampia
 
 Consideriamo la grammatica delle espressioni aritmetiche, visto che siamo partiti da quella; proviamo ad applicare le nostre regole di eliminazione e vediamo cosa succede.
 \begin{align*}
-    \label{non-ll1_grammar}
     \G: E &\to E+T \mid T \\
     T &\to T*F \mid F \nonumber \\
     F &\to (E) \mid id \nonumber 
@@ -705,7 +704,7 @@ Ne abbiamo un ulteriore conferma se andiamo a calcolare i first/follow per \(E\)
 Nota bene: non dobbiamo cadere nell'errore di supporre che, magari, la nostra procedura funzioni a meno che non sia lanciata su grammatiche ambigue, perché non ne abbiamo fornito alcuna prova. Da questo  esempio possiamo solamente concludere, a malincuore, che la procedura di eliminazione della ricorsione sinistra \emph{non garantisce} di ottenere delle grammatiche \(LL(1)\).
 
 \subsection{Eliminare la ricorsione sinistra elimina l'ambiguità?}
-Possiamo però chiederci: la grammatica \(\mathcal{G'}\) che abbiamo ottenuto è ancora ambigua, oppure applicando la nostra procedura ne abbiamo eliminato l'ambiguità? Ricordiamo che l'ambiguità della grammatica di partenza risiedeva nell'impossibilità di esprimere l'associatività degli operatori e la precedenza dell'uno sull'altro \footnote{Si riveda a ~\ref{sec:ambguity} in caso servisse un ripasso.}. 
+Possiamo però chiederci: la grammatica \(\mathcal{G'}\) che abbiamo ottenuto è ancora ambigua, oppure applicando la nostra procedura ne abbiamo eliminato l'ambiguità? Ricordiamo che l'ambiguità della grammatica di partenza risiedeva nell'impossibilità di esprimere l'associatività degli operatori e la precedenza dell'uno sull'altro \footnote{Si riveda a ~\ref{sec:ambiguity} in caso servisse un ripasso.}. 
 
 Sfortunatamente, riusciamo a trovare senza troppi problemi due derivazioni rightmost che ci portano a ottenere la medesima stringa \(id + id * id\):
 \begin{align*}

--- a/src/chapters/08/chapter08.tex
+++ b/src/chapters/08/chapter08.tex
@@ -591,12 +591,12 @@ Una volta terminata l'analisi degli stati e dei relativi item ci preoccupiamo di
     \item i reducing item sono quelli con il marker \(\cdot\) al termine di una produzione, nel nostro caso sono \(E \to id \cdot\) (stato 2), \(E \to E+E \cdot\) (stato 5) e \(E \to E*E \cdot\) (stato 6).
 \end{itemize}
 
-Per concludere la parte di costruzione dell'automa caratteristico per la nostra grammatica in Eq.\ref{eq:ex2-sh/re-grammar}, inseriamo in Fig.\ref{fig:ex2-sh-re-automata} il disegno di tale sgorbio (scherzo, è carino, sembra un razzetto).
+Per concludere la parte di costruzione dell'automa caratteristico per la nostra grammatica in Eq.\ref{eq:ex2-sh/re-grammar}, inseriamo in Fig.\ref{fig:ex2-sh/re-automata} il disegno di tale sgorbio (scherzo, è carino, sembra un razzetto).
 \begin{figure}[H]
     \center
 	\subimport{assets/figures/}{automa_caract_8-4.tex}
     \caption{Automa caratteristico per la grammatica \ref{eq:ex2-sh/re-grammar}}
-    \label{fig:ex2-sh-re-automata}
+    \label{fig:ex2-sh/re-automata}
 \end{figure}
 
 \subsection{Gestione dei conflitti}

--- a/src/chapters/08/chapter08.tex
+++ b/src/chapters/08/chapter08.tex
@@ -723,7 +723,7 @@ Inoltre, se ad esempio avessimo scritto \(T \to id * T\), avremmo perso la left-
 \subsubsection{Esercizio sulla risoluzione dei conflitti}
 Sia data la seguente grammatica:
 \begin{align}
-    \label{eq:ex3-slr1-grammarr}
+    \label{eq:ex3-slr1-grammar}
     \G: S &\to aAd \mid bBd \mid aBe \mid bAe \\
     A &\to c \nonumber \\ \notag
     B &\to c \notag
@@ -796,7 +796,7 @@ La situazione è ben rappresentata dalla figura \ref{fig:lr0-automata_conflict} 
 \begin{figure}[H]
     \centering
     \subimport{assets/figures/}{automa_conflict_LR.tex}
-    \caption{Dettaglio dell'automa di tipo LR(0) per la grammatica \ref{eq:ex3-slr1-grammarr}, si noti come con una \(c\)-transizione si possa arrivare in 6 sia da 3 che da 2}
+    \caption{Dettaglio dell'automa di tipo LR(0) per la grammatica \ref{eq:ex3-slr1-grammar}, si noti come con una \(c\)-transizione si possa arrivare in 6 sia da 3 che da 2}
     \label{fig:lr0-automata_conflict}
 \end{figure}
 

--- a/src/chapters/09/chapter09.tex
+++ b/src/chapters/09/chapter09.tex
@@ -204,7 +204,6 @@ Ora chiederemo al lettore di fare uno sforzo mnemonico poderoso e di ricordare c
     \centering
     \subimport{assets/figures/}{automa_conflict_LR.tex}
     \caption{Automa di tipo LR(0), si noti il conflitto sullo stato 6}
-    \label{fig:lr0-automata_conflict}
 \end{figure}
 Abbiamo già calcolato quali sono gli stati LR(1) per la grammatica in questione in un esercizio precedente (vedi \ref{ex:closure-lr1}), ed applicando l'algoritmo per la costruzione degli automi LR(1) arriviamo ad ottenere il seguente automa (parziale):
 \begin{figure}[H]

--- a/src/chapters/10/chapter10.tex
+++ b/src/chapters/10/chapter10.tex
@@ -334,7 +334,6 @@ Come abbiamo potuto osservare nei capitoli precedenti, l'algoritmo shift/reduce 
 \begin{figure}[H]
     \centering
     \includegraphics[width=1\textwidth]{lalr-automata.jpg}
-    \label{fig:lalr-automata}
 \end{figure}
 
 \begin{table}[H]

--- a/src/chapters/11/chapter11.tex
+++ b/src/chapters/11/chapter11.tex
@@ -96,7 +96,6 @@ Diamo un'occhiata alla generazione del codice intermedio di un'istruzione condiz
     \centering
     \includegraphics[width=.3\textwidth]{if-then-abstract.png}
     \caption{}
-    \label{}
 \end{figure}
 dove l'etichetta \(B.true\) punta al body dell'istruzione condizionale (perché naturalmente vuol dire che la condizione è stata verificata), mentre l'etichetta \(B.false\) punta alla prima istruzione successiva alla chiusura del blocco \texttt{then}.
 
@@ -150,7 +149,6 @@ Supponiamo di voler tradurre un'istruzione condizionale che comprende anche un b
     \centering
     \includegraphics[width=.4\textwidth]{if-else-trans.png}
     \caption{}
-    \label{}
 \end{figure}
 Entrambe le etichette \(S_1.next\) e \(S_2.next\) punteranno all'istruzione successiva all'intero statement.
 \begin{align*}

--- a/src/chapters/12/chapter12.tex
+++ b/src/chapters/12/chapter12.tex
@@ -78,7 +78,7 @@ Le due, ormai ben note, tipologie principali di parsing, sono:
     \item parsing bottom-up.
 \end{itemize} 
 
-\subsection{Parsing top-down\\ \small{Quello bello}}
+\subsection[Parsing top-down]{Parsing top-down \\ \small{Quello bello}}
 Quando ci troviamo al cospetto di grammatiche \(LL(1)\), riusciamo a ricavare il parse tree senza bisogno di backtrack utilizzando il parsing top-down.
 La strategia di analisi del parsing top-down prevede di partire dalla derivazione dello start symbol e poi, utilizzando la derivazione di tipo leftmost, costruire il parse tree.
 Se la grammatica è \(LL(1)\) va tutto liscio ed otteniamo l'albero di parsing in men che non si dica, se non lo è dobbiamo ricorrere al backtrack, ma noi non vogliamo che questo succeda, Larry (se nemmeno voi, come il revisore, avete capito... sorridete e annuite: non si contraddice mai un pazzo).
@@ -90,7 +90,7 @@ Abbiamo quindi visto delle caratteristiche che vogliamo evitare per assicurarci 
     \item Le grammatiche \emph{ambigue} \textbf{non} sono \(LL(1)\), perché esiste almeno una stringa nel linguaggio che può essere derivata in 2 modi diversi (entrambi leftmost).
 \end{itemize}
 
-\subsection{Parsing bottom-up\\ \small{Quello tosto}}
+\subsection[Parsing bottom-up]{Parsing bottom-up\\ \small{Quello tosto}}
 L'altra grossa famigliola di grammatiche che abbiamo visto contiene quelle grammatiche che possono essere analizzate tramite il parsing bottom-up, di questa famiglia siamo andati ad indagare queste tipologie di grammatiche:
 \begin{itemize}
     \item \(SLR\)


### PR DESCRIPTION
Ho corretto diversi warnings principalmente inerenti a:

- caratteri non utilizzabili all'interno delle equazioni (_sostituiti_)
- caratteri o espressioni non utilizzabili all'interno di section o subsection (_sostituiti_)
- label duplicate all'interno dello stesso capitolo (_gestite caso per caso_)
- label all'interno di un componente importato più volte (_spostate all'interno del capitolo dove necessarie_)

Inoltre ho aggiunto il file `Appunti-LFC.code-workspace` e le istruzioni nel `README.md` .
Ho aggiunto di proposito questo file di configurazione in modo che chiunque utilizzi VS Code abbia già tutto pronto, dalla compilazione alla fase di clean dei file non necessari.